### PR TITLE
コンパイルエラーを提出ページに表示

### DIFF
--- a/src/components/organisms/submission/AssemblyError.tsx
+++ b/src/components/organisms/submission/AssemblyError.tsx
@@ -27,7 +27,7 @@ const AssemblyError: FC<AssemblyErrorProps> = ({ errorMessage, sx }) => {
             color: 'white',
           }}
         >
-          {errorMessage}
+          {errorMessage.replaceAll(/\n*$/g, '') /* 文末の改行を消して表示 */}
         </Typography>
       </Box>
     </Box>

--- a/src/components/organisms/submission/AssemblyError.tsx
+++ b/src/components/organisms/submission/AssemblyError.tsx
@@ -1,0 +1,37 @@
+import { Box, Typography } from '@mui/material'
+import type { Theme, SxProps } from '@mui/material/styles'
+import { FC } from 'react'
+
+type AssemblyErrorProps = {
+  errorMessage: string
+  sx?: SxProps<Theme>
+}
+
+const AssemblyError: FC<AssemblyErrorProps> = ({ errorMessage, sx }) => {
+  return (
+    <Box sx={sx}>
+      <Typography variant='h5' sx={{ fontWeight: '600' }}>
+        Assembly error
+      </Typography>
+      <Box
+        sx={{
+          bgcolor: 'primary.main',
+          p: '1rem',
+          mt: '1rem',
+          borderRadius: '6px',
+          whiteSpace: 'pre-wrap',
+        }}
+      >
+        <Typography
+          sx={{
+            color: 'white',
+          }}
+        >
+          {errorMessage}
+        </Typography>
+      </Box>
+    </Box>
+  )
+}
+
+export default AssemblyError

--- a/src/components/organisms/submission/SubmitSourceCode.tsx
+++ b/src/components/organisms/submission/SubmitSourceCode.tsx
@@ -1,0 +1,38 @@
+import { Box, Typography } from '@mui/material'
+import type { Theme, SxProps } from '@mui/material/styles'
+import { FC } from 'react'
+import Code from '@/components/atoms/Code'
+import { SubmissionJoined } from '@/features/types'
+
+type SubmitSourceCodeProps = {
+  submission: SubmissionJoined
+  sx?: SxProps<Theme>
+}
+
+const SubmitSourceCode: FC<SubmitSourceCodeProps> = ({ submission, sx }) => {
+  return (
+    <Box sx={sx}>
+      <Typography variant='h4' sx={{ fontWeight: '600', marginBottom: '1rem' }}>
+        Source Code
+      </Typography>
+      {submission.isCE ? (
+        <Typography
+          sx={{
+            display: 'inline-block',
+            backgroundColor: '#ef9a9a',
+            color: 'white',
+            p: '0.5rem 1rem',
+            borderRadius: '10rem',
+            fontWeight: '800',
+          }}
+        >
+          Compile Error Submitted
+        </Typography>
+      ) : (
+        <Code language='assembly'>{submission.asm}</Code>
+      )}
+    </Box>
+  )
+}
+
+export default SubmitSourceCode

--- a/src/features/types/index.ts
+++ b/src/features/types/index.ts
@@ -54,6 +54,7 @@ export type Submission = {
   time: string
   asm: string
   result: string
+  error_message: string
   isCE: boolean
 }
 

--- a/src/pages/api/problems/[id]/submissions.ts
+++ b/src/pages/api/problems/[id]/submissions.ts
@@ -17,6 +17,7 @@ export default function handler(
         asm: 'stop',
         result: 'AC',
         isCE: false,
+        error_message: '',
         user: {
           id: 1,
           name: 'hoge',

--- a/src/pages/api/submissions/[id].ts
+++ b/src/pages/api/submissions/[id].ts
@@ -14,6 +14,7 @@ export default function handler(
       time: '2022/01/01',
       asm: 'mov rax, 1\nmov rax, 1\nmov rax, 1\nmov rax, 1\nmov rax, 1',
       result: 'AC',
+      error_message: '',
       isCE: false,
       user: {
         id: 1,

--- a/src/pages/api/submissions/index.ts
+++ b/src/pages/api/submissions/index.ts
@@ -15,6 +15,7 @@ export default function handler(
     asm: 'stop',
     result: 'AC',
     isCE: false,
+    error_message: '',
     user: {
       id: 1,
       name: 'hoge',

--- a/src/pages/api/submissions/me.ts
+++ b/src/pages/api/submissions/me.ts
@@ -15,6 +15,7 @@ export default function handler(
     asm: 'stop',
     result: 'AC',
     isCE: false,
+    error_message: '',
     user: {
       id: 1,
       name: 'hoge',

--- a/src/pages/submissions/[id].tsx
+++ b/src/pages/submissions/[id].tsx
@@ -86,6 +86,33 @@ const Submission = () => {
                 {submissionResponse.submission.asm}
               </Code>
             )}
+            {submissionResponse.submission.error_message && (
+              <Box
+                sx={{
+                  mt: '2rem',
+                }}
+              >
+                <Typography variant='h5' sx={{ fontWeight: '600' }}>
+                  Judging Error
+                </Typography>
+                <Box
+                  sx={{
+                    bgcolor: 'primary.main',
+                    p: '1rem',
+                    mt: '1rem',
+                    borderRadius: '6px',
+                  }}
+                >
+                  <Typography
+                    sx={{
+                      color: 'white',
+                    }}
+                  >
+                    {submissionResponse.submission.error_message}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
           </Box>
           <SubmissionResultTable submission={submissionResponse.submission} />
         </Box>

--- a/src/pages/submissions/[id].tsx
+++ b/src/pages/submissions/[id].tsx
@@ -4,9 +4,10 @@ import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 
-import Code from '@/components/atoms/Code'
 import Loading from '@/components/atoms/Loading'
 import SubmissionResultTable from '@/components/molecules/SubmissionResultTable'
+import AssemblyError from '@/components/organisms/submission/AssemblyError'
+import SubmitSourceCode from '@/components/organisms/submission/SubmitSourceCode'
 import BasicLayout from '@/components/templates/BasicLayout'
 import { useSubmission } from '@/features/api'
 
@@ -28,7 +29,11 @@ const Submission = () => {
     setRefreshInterval(
       submissionResponse?.submission.result === 'Pending' ? 2000 : 0,
     )
-  }, [submissionResponse?.status, submissionResponse?.submission?.result])
+  }, [
+    submissionResponse?.status,
+    submissionResponse?.submission?.result,
+    router,
+  ])
 
   if (isError) {
     return <Error statusCode={isError.status} title={isError.message} />
@@ -61,60 +66,20 @@ const Submission = () => {
         </Alert>
       ) : (
         <Box>
-          <Box sx={{ m: '4rem 0' }}>
-            <Typography
-              variant='h4'
-              sx={{ fontWeight: '600', marginBottom: '1rem' }}
-            >
-              Source Code
-            </Typography>
-            {submissionResponse.submission.isCE ? (
-              <Typography
-                sx={{
-                  display: 'inline-block',
-                  backgroundColor: '#ef9a9a',
-                  color: 'white',
-                  p: '0.5rem 1rem',
-                  borderRadius: '10rem',
-                  fontWeight: '800',
-                }}
-              >
-                Compile Error Submitted
-              </Typography>
-            ) : (
-              <Code language='assembly'>
-                {submissionResponse.submission.asm}
-              </Code>
-            )}
-            {submissionResponse.submission.error_message && (
-              <Box
-                sx={{
-                  mt: '2rem',
-                }}
-              >
-                <Typography variant='h5' sx={{ fontWeight: '600' }}>
-                  Judging Error
-                </Typography>
-                <Box
-                  sx={{
-                    bgcolor: 'primary.main',
-                    p: '1rem',
-                    mt: '1rem',
-                    borderRadius: '6px',
-                    whiteSpace: 'pre-wrap',
-                  }}
-                >
-                  <Typography
-                    sx={{
-                      color: 'white',
-                    }}
-                  >
-                    {submissionResponse.submission.error_message}
-                  </Typography>
-                </Box>
-              </Box>
-            )}
-          </Box>
+          {/* 正常時の表示 */}
+          <SubmitSourceCode
+            submission={submissionResponse.submission}
+            sx={{ m: '4rem 0' }}
+          />
+          {submissionResponse.submission.error_message && (
+            <AssemblyError
+              errorMessage={submissionResponse.submission.error_message}
+              sx={{
+                mt: '2rem',
+              }}
+            />
+          )}
+
           <SubmissionResultTable submission={submissionResponse.submission} />
         </Box>
       )}

--- a/src/pages/submissions/[id].tsx
+++ b/src/pages/submissions/[id].tsx
@@ -101,6 +101,7 @@ const Submission = () => {
                     p: '1rem',
                     mt: '1rem',
                     borderRadius: '6px',
+                    whiteSpace: 'pre-wrap',
                   }}
                 >
                   <Typography


### PR DESCRIPTION
## 概要
コンパイルエラーを提出ページに表示するようにした。

## 懸念点
自前の環境だと、アーキテクチャが異なるエラーしか表示できないので、正しい環境での動作確認が必要