### PR TITLE
コンパイルエラーと通常の提出を切り替え可能に

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
     "@fontsource/roboto": "^4.5.8",
+    "@hookform/resolvers": "^3.3.1",
     "@mui/icons-material": "^5.10.6",
     "@mui/material": "^5.10.7",
     "@types/cookie": "^0.5.1",
@@ -26,7 +27,8 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.39.1",
     "react-syntax-highlighter": "^15.5.0",
-    "swr": "swr@2.0.0-rc.0"
+    "swr": "swr@2.0.0-rc.0",
+    "yup": "^1.2.0"
   },
   "devDependencies": {
     "@types/node": "18.7.23",

--- a/src/components/molecules/HeaderToolbar.tsx
+++ b/src/components/molecules/HeaderToolbar.tsx
@@ -80,14 +80,6 @@ const HeaderToolbar: FC<HeaderToolbarProps> = ({ sx }) => {
       </LinkWithIcon>
 
       <LinkWithIcon
-        href='https://github.com/Alignof/HCCC_Tutorial'
-        iconReactNode={<DoneIcon />}
-        sx={{ mr: '1rem' }}
-      >
-        Tutorial
-      </LinkWithIcon>
-
-      <LinkWithIcon
         href='/ranking'
         iconReactNode={<StarIcon />}
         sx={{ mr: '1rem' }}
@@ -138,6 +130,14 @@ const HeaderToolbar: FC<HeaderToolbarProps> = ({ sx }) => {
           )}
         </Menu>
       </Box>
+
+      <LinkWithIcon
+        href='https://github.com/Alignof/HCCC_Tutorial'
+        iconReactNode={<DoneIcon />}
+        sx={{ mr: '1rem' }}
+      >
+        Tutorial
+      </LinkWithIcon>
 
       <Box sx={{ flexGrow: 1 }} />
 

--- a/src/components/molecules/HeaderToolbar.tsx
+++ b/src/components/molecules/HeaderToolbar.tsx
@@ -54,6 +54,8 @@ const HeaderToolbar: FC<HeaderToolbarProps> = ({ sx }) => {
       return
     }
 
+    // キャッシュクリア
+    await mutate(() => true, undefined, { revalidate: false })
     // データの再検証をしないとログイン済の状態となる
     await mutate('/api/users/me')
     router.push('/login')

--- a/src/components/molecules/MobileHeaderToolbar.tsx
+++ b/src/components/molecules/MobileHeaderToolbar.tsx
@@ -47,6 +47,8 @@ const MobileHeaderToolbar: FC<HeaderToolbarProps> = ({ sx }) => {
       return
     }
 
+    // キャッシュクリア
+    await mutate(() => true, undefined, { revalidate: false })
     // データの再検証をしないとログイン済の状態となる
     await mutate('/api/users/me')
     router.push('/login')

--- a/src/components/molecules/MobileHeaderToolbar.tsx
+++ b/src/components/molecules/MobileHeaderToolbar.tsx
@@ -102,14 +102,6 @@ const MobileHeaderToolbar: FC<HeaderToolbarProps> = ({ sx }) => {
 
       <Menu open={open} anchorEl={anchorEl} onClose={handleClose}>
         <MenuItem>
-          <StyledLinkWithIcon
-            href='https://github.com/Alignof/HCCC_Tutorial'
-            iconReactNode={<Done />}
-          >
-            Tutorial
-          </StyledLinkWithIcon>
-        </MenuItem>
-        <MenuItem>
           <StyledLinkWithIcon href='/ranking' iconReactNode={<StarIcon />}>
             Ranking
           </StyledLinkWithIcon>
@@ -137,6 +129,14 @@ const MobileHeaderToolbar: FC<HeaderToolbarProps> = ({ sx }) => {
             </StyledLinkWithIcon>
           </MenuItem>
         )}
+        <MenuItem>
+          <StyledLinkWithIcon
+            href='https://github.com/Alignof/HCCC_Tutorial'
+            iconReactNode={<Done />}
+          >
+            Tutorial
+          </StyledLinkWithIcon>
+        </MenuItem>
         {user && (
           <MenuItem>
             <ButtonWithIcon

--- a/src/components/organisms/LoginForm.tsx
+++ b/src/components/organisms/LoginForm.tsx
@@ -1,3 +1,4 @@
+import { yupResolver } from '@hookform/resolvers/yup'
 import { Alert, Box, Button, TextField } from '@mui/material'
 import type { SxProps, Theme } from '@mui/material/styles'
 import { useRouter } from 'next/router'
@@ -6,11 +7,7 @@ import { useForm } from 'react-hook-form'
 import { useSWRConfig } from 'swr'
 
 import { requestLogin } from '@/features/api'
-
-type IFormInput = {
-  name: string
-  password: string
-}
+import { LoginFormSchema, loginFormSchema } from '@/features/yupSchema'
 
 type LoginFormProps = {
   sx?: SxProps<Theme>
@@ -23,10 +20,12 @@ const LoginForm: FC<LoginFormProps> = ({ sx }) => {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<IFormInput>()
+  } = useForm<LoginFormSchema>({
+    resolver: yupResolver(loginFormSchema),
+  })
   const router = useRouter()
 
-  const onSubmit = async (data: IFormInput) => {
+  const onSubmit = async (data: LoginFormSchema) => {
     const res = await requestLogin({
       name: data.name,
       password: data.password,
@@ -38,7 +37,7 @@ const LoginForm: FC<LoginFormProps> = ({ sx }) => {
     }
     // データの再検証をしないと表示がログインしていない状態となる
     await mutate('/api/users/me')
-    router.push('/')
+    await router.push('/')
   }
 
   return (
@@ -54,8 +53,8 @@ const LoginForm: FC<LoginFormProps> = ({ sx }) => {
           variant='outlined'
           fullWidth
           error={'name' in errors}
-          helperText={errors.name ? 'この項目は必須です' : ''}
-          {...register('name', { required: true })}
+          helperText={errors.name?.message ?? ''}
+          {...register('name')}
         />
       </Box>
 
@@ -66,8 +65,8 @@ const LoginForm: FC<LoginFormProps> = ({ sx }) => {
           variant='outlined'
           fullWidth
           error={'password' in errors}
-          helperText={errors.password ? 'この項目は必須です' : ''}
-          {...register('password', { required: true })}
+          helperText={errors.password?.message ?? ''}
+          {...register('password')}
         />
       </Box>
       <Box

--- a/src/components/organisms/LoginForm.tsx
+++ b/src/components/organisms/LoginForm.tsx
@@ -35,6 +35,9 @@ const LoginForm: FC<LoginFormProps> = ({ sx }) => {
       setErrorMessage(res.errorMessage)
       return
     }
+
+    // キャッシュクリア
+    await mutate(() => true, undefined, { revalidate: false })
     // データの再検証をしないと表示がログインしていない状態となる
     await mutate('/api/users/me')
     await router.push('/')

--- a/src/components/organisms/RegisterForm.tsx
+++ b/src/components/organisms/RegisterForm.tsx
@@ -35,6 +35,9 @@ const RegisterForm: FC<RegisterFormProps> = ({ sx }) => {
       setErrorMessage(res.errorMessage)
       return
     }
+
+    // キャッシュクリア
+    await mutate(() => true, undefined, { revalidate: false })
     // データの再検証をしないとログインしていない状態となる
     await mutate('/api/users/me')
     await router.push('/')

--- a/src/components/organisms/RegisterForm.tsx
+++ b/src/components/organisms/RegisterForm.tsx
@@ -1,3 +1,4 @@
+import { yupResolver } from '@hookform/resolvers/yup'
 import { Alert, Box, Button, TextField } from '@mui/material'
 import type { SxProps, Theme } from '@mui/material/styles'
 import { useRouter } from 'next/router'
@@ -6,11 +7,7 @@ import { useForm } from 'react-hook-form'
 import { useSWRConfig } from 'swr'
 
 import { requestRegister } from '@/features/api'
-
-type IFormInput = {
-  name: string
-  password: string
-}
+import { RegisterFormSchema, registerFormSchema } from '@/features/yupSchema'
 
 type RegisterFormProps = {
   sx?: SxProps<Theme>
@@ -24,9 +21,11 @@ const RegisterForm: FC<RegisterFormProps> = ({ sx }) => {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<IFormInput>()
+  } = useForm<RegisterFormSchema>({
+    resolver: yupResolver(registerFormSchema),
+  })
 
-  const onSubmit = async (data: IFormInput) => {
+  const onSubmit = async (data: RegisterFormSchema) => {
     const res = await requestRegister({
       name: data.name,
       password: data.password,
@@ -38,7 +37,7 @@ const RegisterForm: FC<RegisterFormProps> = ({ sx }) => {
     }
     // データの再検証をしないとログインしていない状態となる
     await mutate('/api/users/me')
-    router.push('/')
+    await router.push('/')
   }
 
   return (
@@ -54,8 +53,8 @@ const RegisterForm: FC<RegisterFormProps> = ({ sx }) => {
           variant='outlined'
           fullWidth
           error={'name' in errors}
-          helperText={errors.name ? 'この項目は必須です' : ''}
-          {...register('name', { required: true })}
+          helperText={errors.name?.message ?? ''}
+          {...register('name')}
         />
       </Box>
 
@@ -66,8 +65,8 @@ const RegisterForm: FC<RegisterFormProps> = ({ sx }) => {
           variant='outlined'
           fullWidth
           error={'password' in errors}
-          helperText={errors.password ? 'この項目は必須です' : ''}
-          {...register('password', { required: true })}
+          helperText={errors.password?.message ?? ''}
+          {...register('password')}
         />
       </Box>
       <Button

--- a/src/components/organisms/problem/SubmitSection.tsx
+++ b/src/components/organisms/problem/SubmitSection.tsx
@@ -1,13 +1,23 @@
-import { Alert, Box, Button, TextField, Typography } from '@mui/material'
+import { yupResolver } from '@hookform/resolvers/yup'
+import {
+  Alert,
+  Box,
+  Button,
+  FormControlLabel,
+  Switch,
+  TextField,
+  Typography,
+} from '@mui/material'
 import type { SxProps, Theme } from '@mui/material/styles'
-import { FC, KeyboardEventHandler } from 'react'
+import React, { FC, KeyboardEventHandler } from 'react'
 import { useForm } from 'react-hook-form'
 import TitleLabel from '@/components/atoms/TitleLabel'
+import { SubmitFormSchema, submitFormSchema } from '@/features/yupSchema'
 
 type SubmitSectionProps = {
   hasWCSubmission: boolean
   errorMessage: string
-  onSubmit: (data: SubmitFormInput) => void
+  onSubmit: (data: SubmitFormSchema) => void
   sx?: SxProps<Theme>
 }
 
@@ -20,8 +30,13 @@ const SubmitSection: FC<SubmitSectionProps> = ({
   const {
     register,
     handleSubmit,
+    watch,
+    clearErrors,
     formState: { errors },
-  } = useForm<SubmitFormInput>()
+  } = useForm<SubmitFormSchema>({
+    resolver: yupResolver(submitFormSchema),
+  })
+  const isCEChecked = watch('isCE')
 
   const handleKeyDown: KeyboardEventHandler<
     HTMLInputElement | HTMLTextAreaElement
@@ -83,6 +98,19 @@ const SubmitSection: FC<SubmitSectionProps> = ({
             {errorMessage && <Alert severity='error'>{errorMessage}</Alert>}
           </Box>
 
+          <FormControlLabel
+            label='Compile Error'
+            control={
+              <Switch
+                {...register('isCE', {
+                  onChange: () => {
+                    clearErrors()
+                  },
+                })}
+              />
+            }
+          />
+
           <TextField
             color='primary'
             label='submission'
@@ -92,12 +120,14 @@ const SubmitSection: FC<SubmitSectionProps> = ({
             fullWidth
             placeholder='input assembly'
             error={'asm' in errors}
-            helperText={errors.asm ? 'この項目は必須です' : ''}
-            {...register('asm', { required: true })}
+            helperText={errors.asm?.message ?? ''}
+            {...register('asm')}
             InputProps={{
               onKeyDown: handleKeyDown,
             }}
+            disabled={isCEChecked}
           />
+
           <Box sx={{ display: 'flex', justifyContent: 'center', m: '4rem' }}>
             <Button
               variant='contained'

--- a/src/components/organisms/problem/SubmitSection.tsx
+++ b/src/components/organisms/problem/SubmitSection.tsx
@@ -1,0 +1,125 @@
+import { Alert, Box, Button, TextField, Typography } from '@mui/material'
+import type { SxProps, Theme } from '@mui/material/styles'
+import { FC, KeyboardEventHandler } from 'react'
+import { useForm } from 'react-hook-form'
+import TitleLabel from '@/components/atoms/TitleLabel'
+
+type SubmitSectionProps = {
+  hasWCSubmission: boolean
+  errorMessage: string
+  onSubmit: (data: SubmitFormInput) => void
+  sx?: SxProps<Theme>
+}
+
+const SubmitSection: FC<SubmitSectionProps> = ({
+  hasWCSubmission,
+  errorMessage,
+  onSubmit,
+  sx,
+}) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SubmitFormInput>()
+
+  const handleKeyDown: KeyboardEventHandler<
+    HTMLInputElement | HTMLTextAreaElement
+  > = (e) => {
+    const target = e.target as HTMLInputElement | HTMLTextAreaElement
+    const value = target.value
+
+    if (e.key === 'Tab') {
+      e.preventDefault()
+
+      const cursorPosition = target.selectionStart
+      const cursorEndPosition = target.selectionEnd
+      const tab = '\t'
+      if (cursorPosition === null || cursorEndPosition === null) {
+        return
+      }
+
+      target.value =
+        value.substring(0, cursorPosition) +
+        tab +
+        value.substring(cursorEndPosition)
+
+      target.selectionStart = cursorPosition + 1
+      target.selectionEnd = cursorPosition + 1
+    }
+  }
+
+  return (
+    <Box sx={sx}>
+      <TitleLabel label='Submission' sx={{ mb: '2rem' }} />
+
+      {hasWCSubmission ? (
+        <Typography
+          variant='h5'
+          sx={{
+            mt: '5rem',
+            bgcolor: '#ef5350',
+            color: 'white',
+            lineHeight: '1.5',
+            fontWeight: '600',
+            p: '2rem',
+          }}
+        >
+          正しいコードに対し,コンパイルエラーが提出されました. <br />
+          この問題を再び回答することはできません.
+          <br />
+          詳細は
+          <a
+            href='https://github.com/Alignof/Human_C_Compiler_Contest'
+            target='_black'
+          >
+            レギュレーション
+          </a>
+          をご確認ください.
+        </Typography>
+      ) : (
+        <Box>
+          <Box sx={{ m: '2rem 0' }}>
+            {errorMessage && <Alert severity='error'>{errorMessage}</Alert>}
+          </Box>
+
+          <TextField
+            color='primary'
+            label='submission'
+            variant='filled'
+            rows={10}
+            multiline
+            fullWidth
+            placeholder='input assembly'
+            error={'asm' in errors}
+            helperText={errors.asm ? 'この項目は必須です' : ''}
+            {...register('asm', { required: true })}
+            InputProps={{
+              onKeyDown: handleKeyDown,
+            }}
+          />
+          <Box sx={{ display: 'flex', justifyContent: 'center', m: '4rem' }}>
+            <Button
+              variant='contained'
+              size='large'
+              sx={{
+                width: '300px',
+                py: '1.2rem',
+                fontSize: '1.1rem',
+                fontWeight: '700',
+                '&:hover': {
+                  opacity: 0.8,
+                },
+              }}
+              onClick={handleSubmit(onSubmit)}
+            >
+              Submit
+            </Button>
+          </Box>
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+export default SubmitSection

--- a/src/components/organisms/problem/SubmitSection.tsx
+++ b/src/components/organisms/problem/SubmitSection.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
 } from '@mui/material'
 import type { SxProps, Theme } from '@mui/material/styles'
+import { styled } from '@mui/material/styles'
 import React, { FC, KeyboardEventHandler } from 'react'
 import { useForm } from 'react-hook-form'
 import TitleLabel from '@/components/atoms/TitleLabel'
@@ -101,7 +102,8 @@ const SubmitSection: FC<SubmitSectionProps> = ({
           <FormControlLabel
             label='Compile Error'
             control={
-              <Switch
+              <StyledSwitch
+                color='error'
                 {...register('isCE', {
                   onChange: () => {
                     clearErrors()
@@ -109,6 +111,13 @@ const SubmitSection: FC<SubmitSectionProps> = ({
                 })}
               />
             }
+            sx={(theme) => ({
+              mb: '1rem',
+              '& .MuiFormControlLabel-label': {
+                color: theme.palette.error.main,
+                fontWeight: 600,
+              },
+            })}
           />
 
           <TextField
@@ -151,5 +160,27 @@ const SubmitSection: FC<SubmitSectionProps> = ({
     </Box>
   )
 }
+
+const StyledSwitch = styled(Switch)(() => ({
+  width: 80,
+  height: 45,
+  padding: 7,
+  '& .MuiSwitch-switchBase': {
+    margin: 1,
+    padding: 0,
+    transform: 'translateX(6px)',
+    '&.Mui-checked': {
+      transform: 'translateX(32px)',
+    },
+  },
+
+  '& .MuiSwitch-thumb': {
+    width: 40,
+    height: 40,
+  },
+  '& .MuiSwitch-track': {
+    borderRadius: 25,
+  },
+}))
 
 export default SubmitSection

--- a/src/features/types/form.ts
+++ b/src/features/types/form.ts
@@ -1,3 +1,0 @@
-type SubmitFormInput = {
-  asm: string
-}

--- a/src/features/types/form.ts
+++ b/src/features/types/form.ts
@@ -1,0 +1,3 @@
+type SubmitFormInput = {
+  asm: string
+}

--- a/src/features/yupSchema.ts
+++ b/src/features/yupSchema.ts
@@ -1,0 +1,13 @@
+import * as yup from 'yup'
+
+export const submitFormSchema = yup
+  .object({
+    isCE: yup.boolean().required(),
+    asm: yup.string().when('isCE', {
+      is: (isCE: boolean) => isCE === false,
+      then: (schema) => schema.required('この項目は必須です'),
+    }),
+  })
+  .required()
+
+export type SubmitFormSchema = yup.InferType<typeof submitFormSchema>

--- a/src/features/yupSchema.ts
+++ b/src/features/yupSchema.ts
@@ -10,4 +10,16 @@ export const submitFormSchema = yup
   })
   .required()
 
+export const loginFormSchema = yup.object({
+  name: yup.string().required('この項目は必須です'),
+  password: yup.string().required('この項目は必須です'),
+})
+
+export const registerFormSchema = yup.object({
+  name: yup.string().required('この項目は必須です'),
+  password: yup.string().required('この項目は必須です'),
+})
+
 export type SubmitFormSchema = yup.InferType<typeof submitFormSchema>
+export type LoginFormSchema = yup.InferType<typeof loginFormSchema>
+export type RegisterFormSchema = yup.InferType<typeof registerFormSchema>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,8 @@
 import CssBaseline from '@mui/material/CssBaseline'
 import { createTheme, ThemeProvider } from '@mui/material/styles'
 import type { AppProps } from 'next/app'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
 import { SWRConfig } from 'swr'
 
 import '@fontsource/roboto/300.css'
@@ -9,6 +11,7 @@ import '@fontsource/roboto/500.css'
 import '@fontsource/roboto/700.css'
 import '@fontsource/roboto/900.css'
 
+import Loading from '@/components/atoms/Loading'
 import AuthProvider from '@/components/contexts/AuthProvider'
 import '@/styles/global.css'
 
@@ -41,12 +44,33 @@ const theme = createTheme({
 })
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const router = useRouter()
+  const [isPageLoading, setIsPageLoading] = useState(false)
+
+  useEffect(() => {
+    // ページ遷移時にロード画面を表示する
+    const handleStart = (url: string) =>
+      url !== router.asPath && setIsPageLoading(true)
+    const handleComplete = () => setIsPageLoading(false)
+
+    router.events.on('routeChangeStart', handleStart)
+    router.events.on('routeChangeComplete', handleComplete)
+    router.events.on('routeChangeError', handleComplete)
+
+    return () => {
+      router.events.off('routeChangeStart', handleStart)
+      router.events.off('routeChangeComplete', handleComplete)
+      router.events.off('routeChangeError', handleComplete)
+    }
+  })
+
   return (
     <SWRConfig value={{ provider: () => new Map() }}>
       <ThemeProvider theme={theme}>
         <AuthProvider>
           <CssBaseline />
           <Component {...pageProps} />
+          {isPageLoading && <Loading />}
         </AuthProvider>
       </ThemeProvider>
     </SWRConfig>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import '@fontsource/roboto/700.css'
 import '@fontsource/roboto/900.css'
 
 import AuthProvider from '@/components/contexts/AuthProvider'
-import '../styles/global.css'
+import '@/styles/global.css'
 
 const theme = createTheme({
   palette: {

--- a/src/pages/problems/[id].tsx
+++ b/src/pages/problems/[id].tsx
@@ -55,8 +55,8 @@ const Problem = () => {
       return
     }
 
-    await router.push(`/submissions/${res.submission.id}/`)
     setIsPostLoading(false)
+    await router.push(`/submissions/${res.submission.id}/`)
   }
 
   if (isProblemError) {

--- a/src/pages/problems/[id].tsx
+++ b/src/pages/problems/[id].tsx
@@ -15,6 +15,7 @@ import {
   requestSubmission,
   useSubmissionList,
 } from '@/features/api'
+import { SubmitFormSchema } from '@/features/yupSchema'
 
 const Problem = () => {
   const router = useRouter()
@@ -40,20 +41,22 @@ const Problem = () => {
     }
   }, [router, problemResponse?.status])
 
-  const onSubmit = async (data: SubmitFormInput) => {
+  const onSubmit = async (data: SubmitFormSchema) => {
     setIsPostLoading(true)
+    const asm = data.isCE ? 'compile error submitted' : data.asm
     const res = await requestSubmission(Number(id), {
-      asm: data.asm,
-      isCE: false,
+      asm: asm || '',
+      isCE: data.isCE,
     })
-    setIsPostLoading(false)
 
     if (res.status === 'ng') {
       setErrorMessage(res.errorMessage)
+      setIsPostLoading(false)
       return
     }
 
-    router.push(`/submissions/${res.submission.id}/`)
+    await router.push(`/submissions/${res.submission.id}/`)
+    setIsPostLoading(false)
   }
 
   if (isProblemError) {

--- a/src/pages/problems/[id].tsx
+++ b/src/pages/problems/[id].tsx
@@ -1,21 +1,14 @@
-import {
-  Typography,
-  TextField,
-  Button,
-  Box,
-  Alert,
-  AlertTitle,
-} from '@mui/material'
+import { Typography, Box, Alert, AlertTitle } from '@mui/material'
 import Error from 'next/error'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-import { useState, useEffect, KeyboardEventHandler } from 'react'
-import { useForm } from 'react-hook-form'
+import { useState, useEffect } from 'react'
 
 import Code from '@/components/atoms/Code'
 import Loading from '@/components/atoms/Loading'
 import TitleLabel from '@/components/atoms/TitleLabel'
 import { useAuthContext } from '@/components/contexts/AuthProvider'
+import SubmitSection from '@/components/organisms/problem/SubmitSection'
 import BasicLayout from '@/components/templates/BasicLayout'
 import {
   useProblem,
@@ -23,46 +16,31 @@ import {
   useSubmissionList,
 } from '@/features/api'
 
-type IFormInput = {
-  asm: string
-}
-
 const Problem = () => {
   const router = useRouter()
   const { id } = router.query
   const { user } = useAuthContext()
 
-  const {
-    problemResponse,
-    isLoading: isProblemLoading,
-    isError: isProblemError,
-  } = useProblem(Number(id))
-  const {
-    submissionListResponse,
-    isLoading: isSubmissionLoading,
-    isError: isSubmissionError,
-  } = useSubmissionList(user?.id)
+  const { problemResponse, isError: isProblemError } = useProblem(Number(id))
+  const { submissionListResponse, isError: isSubmissionError } =
+    useSubmissionList(user?.id)
 
   const [errorMessage, setErrorMessage] = useState('')
   const [isPostLoading, setIsPostLoading] = useState(false)
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<IFormInput>()
 
-  const hasWCSubmission = submissionListResponse?.items
-    ?.filter((v) => v.problem.id === Number(id))
-    .reduce((pv, cv) => pv || cv.result === 'WC', false)
+  const hasWCSubmission =
+    submissionListResponse?.items
+      ?.filter((v) => v.problem.id === Number(id))
+      .reduce((pv, cv) => pv || cv.result === 'WC', false) ?? false
 
   useEffect(() => {
     if (problemResponse?.status === 'login-required') {
       router.push('/login')
       return
     }
-  }, [problemResponse?.status])
+  }, [router, problemResponse?.status])
 
-  const onSubmit = async (data: IFormInput) => {
+  const onSubmit = async (data: SubmitFormInput) => {
     setIsPostLoading(true)
     const res = await requestSubmission(Number(id), {
       asm: data.asm,
@@ -76,48 +54,6 @@ const Problem = () => {
     }
 
     router.push(`/submissions/${res.submission.id}/`)
-  }
-
-  const handleCEClick = async () => {
-    setIsPostLoading(true)
-    const res = await requestSubmission(Number(id), {
-      asm: 'compile error submitted',
-      isCE: true,
-    })
-    setIsPostLoading(false)
-
-    if (res.status === 'ng') {
-      setErrorMessage(res.errorMessage)
-      return
-    }
-
-    router.push(`/submissions/${res.submission.id}/`)
-  }
-
-  const handleKeyDown: KeyboardEventHandler<
-    HTMLInputElement | HTMLTextAreaElement
-  > = (e) => {
-    const target = e.target as HTMLInputElement | HTMLTextAreaElement
-    const value = target.value
-
-    if (e.key === 'Tab') {
-      e.preventDefault()
-
-      const cursorPosition = target.selectionStart
-      const cursorEndPosition = target.selectionEnd
-      const tab = '\t'
-      if (cursorPosition === null || cursorEndPosition === null) {
-        return
-      }
-
-      target.value =
-        value.substring(0, cursorPosition) +
-        tab +
-        value.substring(cursorEndPosition)
-
-      target.selectionStart = cursorPosition + 1
-      target.selectionEnd = cursorPosition + 1
-    }
   }
 
   if (isProblemError) {
@@ -139,10 +75,8 @@ const Problem = () => {
   }
 
   if (
-    isProblemLoading ||
     !problemResponse ||
     problemResponse.status === 'login-required' ||
-    isSubmissionLoading ||
     !submissionListResponse ||
     submissionListResponse.status === 'login-required'
   ) {
@@ -176,7 +110,7 @@ const Problem = () => {
           </Typography>
 
           <Box sx={{ m: '5rem 0 10rem' }}>
-            <TitleLabel label='問題文' sx={{ mb: '2rem' }} />
+            <TitleLabel label='Problem' sx={{ mb: '2rem' }} />
             <Typography variant='h6' sx={{ p: '1rem' }}>
               {problem.statement}
             </Typography>
@@ -201,98 +135,12 @@ const Problem = () => {
             <Typography variant='h6'>{problem.output_desc}</Typography>
           </Box>
 
-          <Box sx={{ m: '10rem 0' }}>
-            <TitleLabel label='Submission' sx={{ mb: '2rem' }} />
-
-            {hasWCSubmission ? (
-              <Typography
-                variant='h5'
-                sx={{
-                  mt: '5rem',
-                  bgcolor: '#ef5350',
-                  color: 'white',
-                  lineHeight: '1.5',
-                  fontWeight: '600',
-                  p: '2rem',
-                }}
-              >
-                正しいコードに対し,コンパイルエラーが提出されました. <br />
-                この問題を再び回答することはできません.
-                <br />
-                詳細は
-                <a
-                  href='https://github.com/Alignof/Human_C_Compiler_Contest'
-                  target='_black'
-                >
-                  レギュレーション
-                </a>
-                をご確認ください.
-              </Typography>
-            ) : (
-              <Box>
-                <Box sx={{ m: '2rem 0' }}>
-                  {errorMessage && (
-                    <Alert severity='error'>{errorMessage}</Alert>
-                  )}
-                </Box>
-
-                <TextField
-                  color='primary'
-                  label='submission'
-                  variant='filled'
-                  rows={10}
-                  multiline
-                  fullWidth
-                  placeholder='input assembly'
-                  error={'asm' in errors}
-                  helperText={errors.asm ? 'この項目は必須です' : ''}
-                  {...register('asm', { required: true })}
-                  InputProps={{
-                    onKeyDown: handleKeyDown,
-                  }}
-                />
-                <Box
-                  sx={{ display: 'flex', justifyContent: 'center', m: '4rem' }}
-                >
-                  <Button
-                    variant='contained'
-                    size='large'
-                    sx={{
-                      width: '300px',
-                      py: '1.2rem',
-                      fontSize: '1.1rem',
-                      fontWeight: '700',
-                      '&:hover': {
-                        opacity: 0.8,
-                      },
-                    }}
-                    onClick={handleSubmit(onSubmit)}
-                  >
-                    Submit
-                  </Button>
-                  <Button
-                    variant='contained'
-                    size='large'
-                    sx={{
-                      width: '300px',
-                      backgroundColor: '#ff3939',
-                      ml: '1.5rem',
-                      py: '1.2rem',
-                      fontSize: '1.1rem',
-                      fontWeight: '700',
-                      '&:hover': {
-                        backgroundColor: '#ff3939',
-                        opacity: 0.8,
-                      },
-                    }}
-                    onClick={handleCEClick}
-                  >
-                    Compile Error
-                  </Button>
-                </Box>
-              </Box>
-            )}
-          </Box>
+          <SubmitSection
+            hasWCSubmission={hasWCSubmission}
+            onSubmit={onSubmit}
+            errorMessage={errorMessage}
+            sx={{ m: '10rem 0' }}
+          />
         </Box>
       )}
 

--- a/src/pages/ranking.tsx
+++ b/src/pages/ranking.tsx
@@ -11,7 +11,7 @@ import BasicLayout from '@/components/templates/BasicLayout'
 import { useRanking } from '@/features/api'
 
 const Ranking: NextPage = () => {
-  const { rankingResponse, isLoading, isError } = useRanking()
+  const { rankingResponse, isError } = useRanking()
 
   if (isError) {
     return <Error statusCode={isError.status} title={isError.message} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,6 +249,11 @@
   resolved "https://registry.yarnpkg.com/@fontsource/roboto/-/roboto-4.5.8.tgz#56347764786079838faf43f0eeda22dd7328437f"
   integrity sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA==
 
+"@hookform/resolvers@^3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-3.3.1.tgz#b7cbfe767434f52cba6b99b0a9a0b73eb8895188"
+  integrity sha512-K7KCKRKjymxIB90nHDQ7b9nli474ru99ZbqxiqDAWYsYhOsU3/4qLxW91y+1n04ic13ajjZ66L3aXbNef8PELQ==
+
 "@humanwhocodes/config-array@^0.10.5":
   version "0.10.7"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.10.7.tgz#6d53769fd0c222767e6452e8ebda825c22e9f0dc"
@@ -2756,6 +2761,11 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     object-assign "^4.1.1"
     react-is "^16.13.1"
 
+property-expr@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
+  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
+
 property-information@^5.0.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.6.0.tgz#61675545fb23002f245c6540ec46077d4da3ed69"
@@ -3166,6 +3176,11 @@ time-span@4.0.0:
   dependencies:
     convert-hrtime "^3.0.0"
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
@@ -3177,6 +3192,11 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -3253,6 +3273,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 typescript@4.8.4:
   version "4.8.4"
@@ -3401,3 +3426,13 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.2.0.tgz#9e51af0c63bdfc9be0fdc6c10aa0710899d8aff6"
+  integrity sha512-PPqYKSAXjpRCgLgLKVGPA33v5c/WgEx3wi6NFjIiegz90zSwyMpvTFp/uGcVnnbx6to28pgnzp/q8ih3QRjLMQ==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"


### PR DESCRIPTION
## 概要
Issue #24 

## スクリーンショット
<img width="500" alt="image" src="https://github.com/HumanCCompilerContest/Human-C-Compiler-Contest_frontend/assets/80200187/fa64f2e9-f6db-487c-94c2-7a02063f4c08">

## その他修正点
- ログイン・新規登録時に起こるキャッシュのバグを修正
- ページ遷移でローディング画面を表示
- yupの導入

Close #24 
Close #25 